### PR TITLE
Rotational fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,57 @@
   - **Zero Fill**: Quick erasure by writing zeros to all addressable locations
 - Works with ATA Secure Erase for compatible devices
 
-> ⚠️ **SSD COMPATIBILITY WARNING**
-> 
-> While this tool can detect and work with SSDs, please note:
-> 
-> - **SSD Wear Leveling**: Makes traditional overwrite methods less effective
-> - **Over-provisioning**: Hidden reserved space may retain data
-> - **Device Lifespan**: Multiple passes can reduce SSD longevity
-> 
-> For SSDs, cryptographic erasure methods are recommended over multiple overwrite passes.
+⚠️ **SSD COMPATIBILITY WARNING**
+
+While this tool can detect and work with SSDs, please note:
+
+- **SSD Wear Leveling**: Makes traditional overwrite methods less effective
+- **Over-provisioning**: Hidden reserved space may retain data
+- **Device Lifespan**: Multiple passes can reduce SSD longevity
+ 
+For SSDs, cryptographic erasure methods are recommended over multiple overwrite passes.
+
+⚠️ **USB FLASH DRIVE PERFORMANCE WARNING**
+ 
+The Linux kernel often incorrectly marks USB flash drives as rotational devices, which can significantly impact performance during erasure operations. This is a known kernel issue affecting USB storage devices.
+ 
+**To fix this issue when NOT using the custom ISO**, create the following udev rule:
+
+This rule is available on stackexchange : [Solution from stackexchange](https://unix.stackexchange.com/questions/439109/set-usb-flash-drive-as-non-rotational-drive)
+
+1. Create the file `/etc/udev/rules.d/usb-flash.rules` with root privileges:
+```bash
+sudo nano /etc/udev/rules.d/usb-flash.rules
+```
+
+2. Add the following content:
+
+```bash
+# Try to catch USB flash drives and set them as non-rotational
+# c.f. https://mpdesouza.com/blog/kernel-adventures-are-usb-sticks-rotational-devices/
+
+# Device is already marked as non-rotational, skip over it
+ATTR{queue/rotational}=="0", GOTO="skip"
+
+# Device has some sort of queue support, likely to be an HDD actually
+ATTRS{queue_type}!="none", GOTO="skip"
+
+# Flip the rotational bit on this removable device and give audible signs of having caught a match
+ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", ATTR{queue/rotational}="0"
+ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/beep -f 70 -r 2"
+
+LABEL="skip"
+```
+
+3. Reload udev rules and restart the udev service:
+```bash
+sudo udevadm control --reload-rules
+sudo systemctl restart systemd-udevd
+```
+ 
+4. Reconnect your USB flash drives to apply the new rules.
+
+**Note**: The custom ISO images already include these optimization rules.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ sudo systemctl restart systemd-udevd
 ## Features ✨
 
 - **Dual Interface**: CLI and GUI modes for flexibility
-- **Smart Device Detection**: Automatically identifies SSDs vs HDDs
+- **Smart Device Detection**: Automatically identifies electronic vs mechanical devices
 - **LVM Support**: Handles LVM disk management
 - **Secure Erasure Methods**:
   - Multiple overwrite passes for HDDs
@@ -143,7 +143,7 @@ sudo diskeraser --cli     # CLI mode
    ```
    - Pre-built ISO
 
-   Download pre-built: [Disk Eraser ISO v5.2](https://archive.org/details/diskEraser-V5.2)
+   Download pre-built: [Disk Eraser ISO v5.3](https://archive.org/details/diskEraser-v5.3)
 
 2. **Flash to USB**:
    ```bash

--- a/code/cli_interface.py
+++ b/code/cli_interface.py
@@ -37,7 +37,7 @@ def print_disk_details(disk):
         print(f"Disk: /dev/{disk}")
         print(f"  Serial/ID: {disk_id}")
         print(f"  Size: {disk_size}")
-        print(f"  Type: {'SSD' if is_disk_ssd else 'HDD'}")
+        print(f"  Type: {'Solid_state' if is_disk_ssd else 'Mechanical'}")
         print(f"  Status: {'ACTIVE SYSTEM DISK - DANGER!' if is_active else 'Safe to erase'}")
         
         if is_disk_ssd:

--- a/code/gui_interface.py
+++ b/code/gui_interface.py
@@ -278,7 +278,7 @@ class DiskEraserGUI:
             device_name = disk['device'].replace('/dev/', '')
             disk_identifier = get_disk_serial(device_name)
             is_device_ssd = is_ssd(device_name)
-            ssd_indicator = " (SSD)" if is_device_ssd else " (HDD)"
+            ssd_indicator = " (Solid_state)" if is_device_ssd else " (Mechanical)"
             
             # Determine if this is the active disk
             base_device_name = get_base_disk(device_name)

--- a/iso/forgeIsoKde.sh
+++ b/iso/forgeIsoKde.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Variables
-ISO_NAME="diskEraserKde-V5.2.iso"
+ISO_NAME="diskEraserKde-v5.3.iso"
 WORK_DIR="$HOME/debian-live-build"
 CODE_DIR="$HOME/diskEraser/code"
 

--- a/iso/forgeIsoKde.sh
+++ b/iso/forgeIsoKde.sh
@@ -109,6 +109,26 @@ mkdir -p config/includes.chroot/etc/sudoers.d/
 echo "user ALL=(ALL) NOPASSWD: ALL" > config/includes.chroot/etc/sudoers.d/passwordless
 chmod 0440 config/includes.chroot/etc/sudoers.d/passwordless
 
+# Create USB flash drive udev rules
+echo "Creating USB flash drive udev rules..."
+mkdir -p config/includes.chroot/etc/udev/rules.d/
+cat << 'EOF' > config/includes.chroot/etc/udev/rules.d/usb-flash.rules
+# Try to catch USB flash drives and set them as non-rotational. Probably no impact whatsoever : /
+# c.f. https://mpdesouza.com/blog/kernel-adventures-are-usb-sticks-rotational-devices/
+
+# Device is already marked as non-rotational, skip over it
+ATTR{queue/rotational}=="0", GOTO="skip"
+
+# Device has some sort of queue support, likely to be an HDD actually
+ATTRS{queue_type}!="none", GOTO="skip"
+
+# Flip the rotational bit on this removable device and give audible signs of having caught a match
+ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", ATTR{queue/rotational}="0"
+ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/beep -f 70 -r 2"
+
+LABEL="skip"
+EOF
+
 # Create application launcher for the installed version
 echo "Creating application launcher..."
 mkdir -p config/includes.chroot/usr/share/applications/

--- a/iso/forgeIsoXfce.sh
+++ b/iso/forgeIsoXfce.sh
@@ -108,6 +108,26 @@ mkdir -p config/includes.chroot/etc/sudoers.d/
 echo "user ALL=(ALL) NOPASSWD: ALL" > config/includes.chroot/etc/sudoers.d/passwordless
 chmod 0440 config/includes.chroot/etc/sudoers.d/passwordless
 
+# Create USB flash drive udev rules
+echo "Creating USB flash drive udev rules..."
+mkdir -p config/includes.chroot/etc/udev/rules.d/
+cat << 'EOF' > config/includes.chroot/etc/udev/rules.d/usb-flash.rules
+# Try to catch USB flash drives and set them as non-rotational. Probably no impact whatsoever : /
+# c.f. https://mpdesouza.com/blog/kernel-adventures-are-usb-sticks-rotational-devices/
+
+# Device is already marked as non-rotational, skip over it
+ATTR{queue/rotational}=="0", GOTO="skip"
+
+# Device has some sort of queue support, likely to be an HDD actually
+ATTRS{queue_type}!="none", GOTO="skip"
+
+# Flip the rotational bit on this removable device and give audible signs of having caught a match
+ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", ATTR{queue/rotational}="0"
+ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/beep -f 70 -r 2"
+
+LABEL="skip"
+EOF
+
 # Create application launcher for the installed version
 echo "Creating application launcher..."
 mkdir -p config/includes.chroot/usr/share/applications/

--- a/iso/forgeIsoXfce.sh
+++ b/iso/forgeIsoXfce.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Variables
-ISO_NAME="diskEraser-V5.2.iso"
+ISO_NAME="diskEraser-v5.3.iso"
 WORK_DIR="$HOME/debian-live-build"
 CODE_DIR="$HOME/diskEraser/code"
 


### PR DESCRIPTION
# Fix USB Flash Drive Performance with Udev Rules

## Description

This PR addresses the Linux kernel issue where USB flash drives are incorrectly detected as rotational devices, causing severe performance degradation during disk erasure operations.

## Changes Made

- **Added udev rules** to both XFCE and KDE ISO build scripts (`forgeIsoXfce.sh`, `forgeIsoKde.sh`)
- **Added `beep` package** to provide audible feedback when USB devices are optimized
- **Created `/etc/udev/rules.d/usb-flash.rules`** with automatic USB flash drive detection and optimization
- **Updated README.md** with comprehensive warning about USB performance issues
- **Added step-by-step instructions** for manual udev rule creation for non-ISO users
- **Included system reload commands** to apply udev rules properly

## Technical Details

### Udev Rules Implementation
```bash
# Device is already marked as non-rotational, skip over it
ATTR{queue/rotational}=="0", GOTO="skip"

# Device has some sort of queue support, likely to be an HDD actually
ATTRS{queue_type}!="none", GOTO="skip"

# Flip the rotational bit on this removable device and give audible signs of having caught a match
ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", ATTR{queue/rotational}="0"
ATTR{removable}=="1", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/beep -f 70 -r 2"
```